### PR TITLE
Fix function types in event-finder.ts

### DIFF
--- a/src/event-finder.ts
+++ b/src/event-finder.ts
@@ -81,8 +81,8 @@ export class AstroEvent {
 export interface LunarPhasesHtmlOptions {
   tableClass?: string;
   headers?: string[];
-  formatYear?: (number) => string;
-  formatDateTime?: (AstroEvent) => string;
+  formatYear?: (n: number) => string;
+  formatDateTime?: (ae: AstroEvent) => string;
 }
 
 export interface EquinoxSolsticeHtmlOptions extends LunarPhasesHtmlOptions {
@@ -94,15 +94,15 @@ export interface RiseAndSetHtmlOptions {
   headers?: string[];
   unseenAllDay?: string;
   visibleAllDay?: string;
-  formatDate?: (AstroEvent) => string;
-  formatDay?: (AstroEvent) => string;
-  formatTime?: (AstroEvent) => string;
+  formatDate?: (ae: AstroEvent) => string;
+  formatDay?: (ae: AstroEvent) => string;
+  formatTime?: (ae: AstroEvent) => string;
 }
 
 export interface GalileanMoonsHtmlOptions {
   tableClass?: string;
-  formatDateTime?: (AstroEvent) => string;
-  formatTime?: (AstroEvent) => string;
+  formatDateTime?: (ae: AstroEvent) => string;
+  formatTime?: (ae: AstroEvent) => string;
 }
 
 function esc(s: string): string {


### PR DESCRIPTION
For some function signatures, they only had the type of the argument, and not a corresponding argument name, so TypeScript interpreted the types as the argument names and gave them an implicit "any" type (preventing the use of this library with strict compilation flags)